### PR TITLE
feat: upgrade MongoDB 8.0 -> 8.2 sur le cluster lba (prérequis mongot)

### DIFF
--- a/.bin/commands.sh
+++ b/.bin/commands.sh
@@ -51,7 +51,7 @@ _local_app_deploy_cluster_node_update__help="Update cluster"
 _register "app:deploy:cluster:node:update" "_local_app_deploy_cluster_node_update"
 
 function _local_app_deploy_cluster_node_update() {
-  "${scripts_dir}/app-deploy-cluster-node-update.sh" "$@"
+  "${SCRIPTS_DIR}/app-deploy-cluster-node-update.sh" "$@"
 }
 
 _local_app_deploy_cluster_node_add__help="Add node to existing cluster"

--- a/.infra/ansible/tasks/install_mongodb.yml
+++ b/.infra/ansible/tasks/install_mongodb.yml
@@ -1,12 +1,12 @@
 ---
 - name: "Import the public key used by the package management system"
   get_url:
-    url: "https://www.mongodb.org/static/pgp/server-8.0.asc"
-    dest: /etc/apt/keyrings/mongodb-server-8.0.asc
+    url: "https://www.mongodb.org/static/pgp/server-{{ mongodb_pgp_key_epoch | default('8.0') }}.asc"
+    dest: "/etc/apt/keyrings/mongodb-server-{{ mongodb_pgp_key_epoch | default('8.0') }}.asc"
 
 - name: "Create a list file for MongoDB"
   apt_repository:
-    repo: "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-8.0.asc ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/8.0 multiverse"
+    repo: "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-{{ mongodb_pgp_key_epoch | default('8.0') }}.asc ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/{{ mongodb_channel | default('8.0') }} multiverse"
     state: present
 
 - name: Install MongoDB package

--- a/.infra/ansible/tasks/install_mongodb.yml
+++ b/.infra/ansible/tasks/install_mongodb.yml
@@ -6,7 +6,7 @@
 
 - name: "Create a list file for MongoDB"
   apt_repository:
-    repo: "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-{{ mongodb_pgp_key_epoch | default('8.0') }}.asc ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/{{ mongodb_channel | default('8.0') }} multiverse"
+    repo: "deb [ arch=amd64,arm64 signed-by=/etc/apt/keyrings/mongodb-server-{{ mongodb_pgp_key_epoch | default('8.0') }}.asc ] https://repo.mongodb.org/apt/ubuntu noble/mongodb-org/{{ mongodb_version | default('8.0') }} multiverse"
     state: present
 
 - name: Install MongoDB package

--- a/.infra/inventories/env.ini
+++ b/.infra/inventories/env.ini
@@ -13,7 +13,7 @@ host_name=mongodb-recette-1
 env_type=recette
 ca_name=mongodb_recette_1
 backup_enable=true
-mongodb_channel=8.2
+mongodb_version=8.2
 
 [api_1]
 193.70.75.83
@@ -72,7 +72,7 @@ dns_name=mongodb-lba-1.apprentissage.beta.gouv.fr
 host_name=mongodb-lba-1
 env_type=lba
 ca_name=mongodb_lba_1
-mongodb_channel=8.2
+mongodb_version=8.2
 
 [lba_2]
 152.228.229.138
@@ -81,7 +81,7 @@ dns_name=mongodb-lba-2.apprentissage.beta.gouv.fr
 host_name=mongodb-lba-2
 env_type=lba
 ca_name=mongodb_lba_2
-mongodb_channel=8.2
+mongodb_version=8.2
 
 [lba_3]
 146.59.242.35
@@ -91,7 +91,7 @@ host_name=mongodb-lba-3
 env_type=lba
 ca_name=mongodb_lba_3
 backup_enable=true
-mongodb_channel=8.2
+mongodb_version=8.2
 
 [tdb_1]
 141.95.153.119

--- a/.infra/inventories/env.ini
+++ b/.infra/inventories/env.ini
@@ -13,6 +13,7 @@ host_name=mongodb-recette-1
 env_type=recette
 ca_name=mongodb_recette_1
 backup_enable=true
+mongodb_channel=8.2
 
 [api_1]
 193.70.75.83
@@ -71,6 +72,7 @@ dns_name=mongodb-lba-1.apprentissage.beta.gouv.fr
 host_name=mongodb-lba-1
 env_type=lba
 ca_name=mongodb_lba_1
+mongodb_channel=8.2
 
 [lba_2]
 152.228.229.138
@@ -79,6 +81,7 @@ dns_name=mongodb-lba-2.apprentissage.beta.gouv.fr
 host_name=mongodb-lba-2
 env_type=lba
 ca_name=mongodb_lba_2
+mongodb_channel=8.2
 
 [lba_3]
 146.59.242.35
@@ -88,6 +91,7 @@ host_name=mongodb-lba-3
 env_type=lba
 ca_name=mongodb_lba_3
 backup_enable=true
+mongodb_channel=8.2
 
 [tdb_1]
 141.95.153.119

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Consulter les documentations dédiées à la [sauvegarde](./docs/backup/backup.m
 Pour supprimer un noeud veuillez:
 
 - Supprimer l'adresse du noeud dans l'enregistrement DNS `SRV` sur alwaysdata.
-- Supprimer le noeud du cluster MongoDB via la commande `.bin/mna deploy:remove:node <environnement>-<n>`
+- Supprimer le noeud du cluster MongoDB via la commande `.bin/mna app:deploy:cluster:node:remove <environnement>-<n>`
 - Décommissionner le serveur et le volume externe associé.
 - Supprimer la référence du serveur dans le fichier ini de ce dépôt ainsi que celui du dépôt infra.
 - Supprimer le noeud de [Percona](https://percona.apprentissage.beta.gouv.fr)

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Pour déployer un cluster MongoDB, il est nécessaire de déployer chaque noeud 
 
 Pour migrer un cluster MongoDB existant vers la nouvelle architecture veuillez suivre la procédure [Migration](./docs/deploy/migration.md).
 
+### Mise à jour majeure (upgrade en place)
+
+Pour monter en version majeure un cluster existant sans changer d'architecture, veuillez suivre la procédure [Upgrade](./docs/deploy/upgrade.md).
+
 ### Backup et restauration
 
 Consulter les documentations dédiées à la [sauvegarde](./docs/backup/backup.md) et à la [restauration](./docs/backup/restore.md) des données.

--- a/docs/deploy/add_member.md
+++ b/docs/deploy/add_member.md
@@ -8,7 +8,7 @@ Veuillez suivre la procédure sur [Création d'une instance et d'un volume exter
 
 ## Installation du serveur
 
-Veuillez lancer la commande `.bin/mna deploy:extra:node <environnement>_<n>` pour déployer le serveur.
+Veuillez lancer la commande `.bin/mna app:deploy:cluster:node:add <environnement>_<n>` pour déployer le serveur.
 
 ## Vérification de l'installation
 

--- a/docs/deploy/initial.md
+++ b/docs/deploy/initial.md
@@ -45,7 +45,7 @@ Avec:
 
 ### Déploiement
 
-1. Lancer le déploiement `.bin/mna deploy:initial:node <environnement>_<n>`
+1. Lancer le déploiement `.bin/mna app:deploy:initial:node <environnement>_<n>`
 2. Redémarrer le serveur pour appliquer tous les changements
 
 ### Enregistrement DNS SRV

--- a/docs/deploy/update.md
+++ b/docs/deploy/update.md
@@ -15,5 +15,5 @@ Lancer l'action `Mise à jour d'un Cluster` en spécifiant le nom du cluster à 
 Pour mettre à jour un noeud existant, il suffit de lancer la commande suivante :
 
 ```bash
-.bin/mna deploy:update:node <environnement>-<n>
+.bin/mna app:deploy:cluster:node:update <environnement>_<n>
 ```

--- a/docs/deploy/upgrade.md
+++ b/docs/deploy/upgrade.md
@@ -1,0 +1,91 @@
+# Mise à jour majeure de MongoDB (upgrade en place)
+
+Cette procédure décrit la montée de version majeure d'un cluster existant **en place** (rolling
+upgrade des binaires + passage de la Feature Compatibility Version), sans création d'un nouveau
+cluster. Pour une migration vers une nouvelle architecture de cluster, voir plutôt
+[Migration](./migration.md).
+
+> [!CAUTION]
+> Ne jamais passer la FCV avant d'avoir validé que **tous les membres** du replica set tournent
+> sur la nouvelle version binaire et sont stables depuis quelques jours (burn-in). La FCV est une
+> propriété du replica set (pas d'un nœud individuel) : une seule exécution suffit, sur n'importe
+> quel membre.
+
+## Pré-requis
+
+1. Vérifier la version binaire actuelle et la FCV courante sur un membre du cluster :
+   ```bash
+   /opt/app/scripts/mongo.sh --eval 'db.version()'
+   /opt/app/scripts/mongo.sh --eval 'db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1})'
+   ```
+2. Vérifier la compatibilité des drivers applicatifs avec la version cible (voir la
+   [compatibilité des drivers NodeJS](https://www.mongodb.com/docs/drivers/node/current/compatibility/#compatibility-table-legend)).
+3. Ajouter `mongodb_channel=<version cible>` (ex. `8.2`) dans `.infra/inventories/env.ini`, **uniquement**
+   sous les groupes `[<environnement>_<n>:vars]` des nœuds à mettre à jour. Ne jamais poser cette
+   variable en `[all:vars]` : `install_mongodb.yml` est partagé par tous les clusters, un cluster
+   sans `mongodb_channel` défini reste sur `8.0` par défaut.
+4. Vérifier si la clé PGP de signature a changé d'epoch (`https://www.mongodb.org/static/pgp/server-<epoch>.asc`,
+   par ex. `curl -sIL` doit renvoyer `200`). MongoDB ne republie pas de nouvelle clé à chaque version
+   mineure : la clé `8.0` signe l'ensemble de la série `8.x` (vérifié le 14/07/2026 : `server-8.1.asc`
+   et `server-8.2.asc` renvoient `404`, seule `server-8.0.asc` existe). Si l'epoch n'a pas changé,
+   **ne pas** définir `mongodb_pgp_key_epoch` (reste par défaut sur `8.0`) — seul `mongodb_channel`
+   doit changer. Si une montée de version future change réellement d'epoch de clé (ex. passage à une
+   `9.0`), définir `mongodb_pgp_key_epoch=9.0` en plus de `mongodb_channel=9.0`.
+
+> [!NOTE]
+> Le module `apt_repository` ajoute un nouveau fichier de dépôt pour chaque canal mais ne retire pas
+> l'ancien. Ce n'est pas bloquant (le paquet `mongodb-org*` en `state: latest` installe la version la
+> plus haute disponible parmi les dépôts présents), mais laisse un fichier `mongodb-org-8.0` obsolète
+> sous `/etc/apt/sources.list.d/` après l'upgrade — à nettoyer manuellement si besoin.
+
+## Rolling upgrade des binaires
+
+Suivre la procédure standard [Mettre à jour un nœud existant](./update.md) :
+
+```bash
+.bin/mna deploy:update:node <environnement>-<n>
+```
+
+> [!CAUTION]
+> Vérifier avec `rs.status()` **avant chaque run** quel nœud est réellement `PRIMARY` — ne pas
+> supposer que c'est le nœud `1`. Mettre à jour les secondaires en premier, le primaire en dernier.
+> Ne jamais mettre à jour plusieurs nœuds du même cluster en parallèle.
+
+Après chaque nœud mis à jour, vérifier avant de passer au suivant :
+
+```bash
+/opt/app/scripts/mongo.sh --eval 'rs.status()'
+```
+
+Tous les membres doivent être `HEALTHY` et `db.version()` doit refléter la nouvelle version sur le
+nœud qui vient d'être mis à jour.
+
+## Burn-in
+
+Laisser tourner le cluster complet sur la nouvelle version binaire quelques jours (comportement par
+défaut, FCV encore à l'ancienne valeur) avant de passer à l'étape suivante — cela permet un
+rollback simple en cas de problème inattendu.
+
+## Passage de la Feature Compatibility Version
+
+Une fois le burn-in validé, exécuter **une seule fois** (sur n'importe quel membre du cluster) :
+
+```bash
+/opt/app/scripts/mongo.sh --eval 'db.adminCommand({setFeatureCompatibilityVersion: "<version cible>", confirm: true})'
+```
+
+> [!WARNING]
+> Cette action n'est pas trivialement réversible (voir la doc officielle MongoDB sur le
+> [downgrade de FCV](https://www.mongodb.com/docs/manual/reference/command/setFeatureCompatibilityVersion/)).
+> Ne l'exécuter qu'après confirmation que l'application fonctionne normalement sur la nouvelle
+> version binaire.
+
+## Vérifications post-upgrade
+
+- `db.version()` ≥ version cible sur chaque nœud du cluster concerné.
+- `rs.status()` : tous les membres `HEALTHY`, pas de bascule de primaire imprévue.
+- `db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1})` reflète la version cible.
+- Le backup quotidien (`configure-mongodb-backup.yml`, nœud avec `backup_enable=true`) continue de
+  s'exécuter sans erreur (vérifier les logs CRON du script `backup-database.sh.jinja2`).
+- Logs applicatifs des services connectés au cluster : absence d'erreurs driver
+  (`MongoServerSelectionError`, incompatibilité de version).

--- a/docs/deploy/upgrade.md
+++ b/docs/deploy/upgrade.md
@@ -57,8 +57,8 @@ Après chaque nœud mis à jour, vérifier avant de passer au suivant :
 /opt/app/scripts/mongo.sh --eval 'rs.status()'
 ```
 
-Tous les membres doivent être `HEALTHY` et `db.version()` doit refléter la nouvelle version sur le
-nœud qui vient d'être mis à jour.
+Tous les membres doivent afficher `stateStr: "PRIMARY"` ou `"SECONDARY"` avec `health: 1`, et
+`db.version()` doit refléter la nouvelle version sur le nœud qui vient d'être mis à jour.
 
 ## Burn-in
 
@@ -83,7 +83,7 @@ Une fois le burn-in validé, exécuter **une seule fois** (sur n'importe quel me
 ## Vérifications post-upgrade
 
 - `db.version()` ≥ version cible sur chaque nœud du cluster concerné.
-- `rs.status()` : tous les membres `HEALTHY`, pas de bascule de primaire imprévue.
+- `rs.status()` : tous les membres `PRIMARY`/`SECONDARY` avec `health: 1`, pas de bascule de primaire imprévue.
 - `db.adminCommand({getParameter: 1, featureCompatibilityVersion: 1})` reflète la version cible.
 - Le backup quotidien (`configure-mongodb-backup.yml`, nœud avec `backup_enable=true`) continue de
   s'exécuter sans erreur (vérifier les logs CRON du script `backup-database.sh.jinja2`).

--- a/docs/deploy/upgrade.md
+++ b/docs/deploy/upgrade.md
@@ -20,17 +20,17 @@ cluster. Pour une migration vers une nouvelle architecture de cluster, voir plut
    ```
 2. Vérifier la compatibilité des drivers applicatifs avec la version cible (voir la
    [compatibilité des drivers NodeJS](https://www.mongodb.com/docs/drivers/node/current/compatibility/#compatibility-table-legend)).
-3. Ajouter `mongodb_channel=<version cible>` (ex. `8.2`) dans `.infra/inventories/env.ini`, **uniquement**
+3. Ajouter `mongodb_version=<version cible>` (ex. `8.2`) dans `.infra/inventories/env.ini`, **uniquement**
    sous les groupes `[<environnement>_<n>:vars]` des nœuds à mettre à jour. Ne jamais poser cette
    variable en `[all:vars]` : `install_mongodb.yml` est partagé par tous les clusters, un cluster
-   sans `mongodb_channel` défini reste sur `8.0` par défaut.
-4. Vérifier si la clé PGP de signature a changé d'epoch (`https://www.mongodb.org/static/pgp/server-<epoch>.asc`,
+   sans `mongodb_version` défini reste sur `8.0` par défaut.
+4. Vérifier si la clé OpenPGP de signature a changé d'epoch (`https://www.mongodb.org/static/pgp/server-<epoch>.asc`,
    par ex. `curl -sIL` doit renvoyer `200`). MongoDB ne republie pas de nouvelle clé à chaque version
    mineure : la clé `8.0` signe l'ensemble de la série `8.x` (vérifié le 14/07/2026 : `server-8.1.asc`
    et `server-8.2.asc` renvoient `404`, seule `server-8.0.asc` existe). Si l'epoch n'a pas changé,
-   **ne pas** définir `mongodb_pgp_key_epoch` (reste par défaut sur `8.0`) — seul `mongodb_channel`
+   **ne pas** définir `mongodb_pgp_key_epoch` (reste par défaut sur `8.0`) — seul `mongodb_version`
    doit changer. Si une montée de version future change réellement d'epoch de clé (ex. passage à une
-   `9.0`), définir `mongodb_pgp_key_epoch=9.0` en plus de `mongodb_channel=9.0`.
+   `9.0`), définir `mongodb_pgp_key_epoch=9.0` en plus de `mongodb_version=9.0`.
 
 > [!NOTE]
 > Le module `apt_repository` ajoute un nouveau fichier de dépôt pour chaque canal mais ne retire pas
@@ -43,7 +43,7 @@ cluster. Pour une migration vers une nouvelle architecture de cluster, voir plut
 Suivre la procédure standard [Mettre à jour un nœud existant](./update.md) :
 
 ```bash
-.bin/mna deploy:update:node <environnement>-<n>
+.bin/mna app:deploy:cluster:node:update <environnement>_<n>
 ```
 
 > [!CAUTION]


### PR DESCRIPTION
## Contexte

mongot 1.70.1 (MongoDB Search) exige mongod >= 8.2. Cette PR upgrade le cluster **lba** (recette + prod) en place, avant l'installation de mongot (PR suivante). Scope volontairement limité à lba/recette — les autres clusters (bal, api, tdb, sandbox) ne sont pas concernés.

## Changements

- `install_mongodb.yml` : canal apt paramétré (`mongodb_channel`), découplé de l'epoch de clé PGP (`mongodb_pgp_key_epoch`, reste `8.0` par défaut — vérifié empiriquement que `server-8.2.asc` n'existe pas, MongoDB réutilise la clé `8.0` pour toute la série `8.x`)
- `env.ini` : `mongodb_channel=8.2` ajouté uniquement sous `recette_1`, `lba_1`, `lba_2`, `lba_3`
- `docs/deploy/upgrade.md` (nouveau) : procédure de rolling upgrade + passage FCV, réutilise le script `mongo.sh` existant (pas de nouvelle tâche Ansible pour la FCV, cohérent avec `migration.md`)
- `README.md` : lien vers la nouvelle procédure

## Plan de rollout (hors scope de la PR, à faire après merge)

1. `.bin/mna deploy:update:node recette-1` (valider avant lba)
2. `.bin/mna deploy:update:node lba-3/2/1` (secondaires d'abord, vérifier le primaire réel via `rs.status()` avant d'ordonnancer)
3. Burn-in quelques jours
4. Passage FCV (`mongo.sh --eval 'setFeatureCompatibilityVersion: "8.2"'`)

## Test plan

- [ ] `ansible-playbook deploy.yml --syntax-check` (déjà validé localement)
- [ ] Rollout recette d'abord, vérifier `db.version()` >= 8.2 et `rs.status()` sain
- [ ] Vérifier que les autres clusters (bal/api/tdb/sandbox) ne sont pas affectés (toujours en 8.0 par défaut)
- [ ] Backup quotidien (`backup-database.sh`) toujours fonctionnel après upgrade